### PR TITLE
made sure that no funds are lost due to ED

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 node_modules/
 config/main.yaml
 config/secret.json
+config/config.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 config/main.yaml
 config/secret.json
 config/config.yaml
+config/key.json

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ This tool sends funds from a given Polkadot/Kusama account to two rewards destin
 
 ## Usage
 
-1. Copy `sample.config.yaml` to `main.yaml` and update the values
-1. Export a Polkadot.js.org Wallet to json and store it under `config/wallet.json`
+1. Copy `sample.config.yaml` to `config.yaml` and update the values
+1. Export a Polkadot.js.org Wallet to json and store it under `config/key.json`
 1. Build the script using `yarn install && yarn build` (only needed once or when you change it)
 1. Run the script using `yarn start`
 

--- a/config/sample.config.yaml
+++ b/config/sample.config.yaml
@@ -1,6 +1,6 @@
 end_point: wss://rpc.polkadot.io
 keystore:
-  walletFilePath: config/sample.key.json
+  walletFilePath: config/key.json
   password: "p4ssw0rd"
 rewardsDestination:
   primaryDestinationAddress: 1HigsTaXZrCEEWkbUPwD4Rx6XpV7E9fnsom6ZCx42RJnimr # Change this!!

--- a/config/sample.config.yaml
+++ b/config/sample.config.yaml
@@ -3,6 +3,6 @@ keystore:
   walletFilePath: config/sample.key.json
   password: "p4ssw0rd"
 rewardsDestination:
-  mainDestinationAddress: 1HigsTaXZrCEEWkbUPwD4Rx6XpV7E9fnsom6ZCx42RJnimr # Change this!!
-  mainDestinationShare: 80%
-  dustDestinationAddress: 1HigsTaXZrCEEWkbUPwD4Rx6XpV7E9fnsom6ZCx42RJnimr # Change this!!
+  primaryDestinationAddress: 1HigsTaXZrCEEWkbUPwD4Rx6XpV7E9fnsom6ZCx42RJnimr # Change this!!
+  primaryDestinationShare: 80%
+  secondaryDestinationAddress: 1HigsTaXZrCEEWkbUPwD4Rx6XpV7E9fnsom6ZCx42RJnimr # Change this!!

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,7 +111,7 @@ const start = async (args: { config: string }): Promise<void> => {
   }
 
   log.debug(`Will send ${primaryTransfer} ${api.registry.chainTokens} to ${config.rewardsDestination.primaryDestinationAddress}`)
-  log.debug(`Will send ${secondaryTransfer} ${api.registry.chainTokens} (minus fees) to ${config.rewardsDestination.secondaryDestinationAddress}`)
+  log.debug(`Will send ${secondaryTransfer} ${api.registry.chainTokens} to ${config.rewardsDestination.secondaryDestinationAddress}`)
   
   const transfers = [
     api.tx.balances.transfer(config.rewardsDestination.primaryDestinationAddress, primaryTransfer * base),

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,12 +101,13 @@ const start = async (args: { config: string }): Promise<void> => {
   const primaryTransfer = available_funds * share;
   const secondaryTransfer = available_funds * (1-share);
 
-  // Abort if primary destination does not have enough ED and the transfer would be below ED.
-  if(primaryDestinationOverED == false && (primaryTransfer < existentialDeposit)){
+  // Abort if any of the destination addresses does not have enough ED and the transfer would be below ED. In the case that we do not send
+  // anything to the address, we can proceed even if it is without ED.
+  if(primaryDestinationOverED == false && (primaryTransfer < existentialDeposit) && primaryTransfer != 0){
     abort();
   }
-  // Abort if secondary destination does not have enough ED and the transfer would be below ED.
-  if(secondaryDestinationOverED == false && (secondaryTransfer < existentialDeposit)){
+
+  if(secondaryDestinationOverED == false && (secondaryTransfer < existentialDeposit) && secondaryTransfer != 0){
     abort();
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,7 +133,7 @@ function delay(ms: number) {
 
 const command = new Command()
   .description("Execute the reward transactions")
-  .option("-c, --config [path]", "Path to config file.", "./config/main.yaml")
+  .option("-c, --config [path]", "Path to config file.", "./config/config.yaml")
   .action(start);
 
 command.parse();

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,8 +98,8 @@ const start = async (args: { config: string }): Promise<void> => {
   // in all cases.
   assert(available_funds >= 0)
 
-  const primaryTransfer = available_funds * share;
-  const secondaryTransfer = available_funds * (1-share);
+  const primaryTransfer = Math.round(available_funds * share,10);
+  const secondaryTransfer = Math.round(available_funds * (1-share),10);
 
   // Abort if any of the destination addresses does not have enough ED and the transfer would be below ED. In the case that we do not send
   // anything to the address, we can proceed even if it is without ED.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,12 @@
 import { Command } from "commander";
 import { load } from "js-yaml";
 import { readFileSync, createWriteStream, existsSync, WriteStream } from "fs";
-import { parse } from "csv-parse";
 import { ApiPromise, WsProvider } from "@polkadot/api";
 import { KeyringPair, KeyringPair$Json } from "@polkadot/keyring/types";
 import { Keyring } from "@polkadot/keyring";
 import { createLogger } from "@w3f/logger";
 import '@polkadot/api-augment';
+import { assert } from "console";
 
 interface Config {
   end_point: string;
@@ -15,9 +15,9 @@ interface Config {
 }
 
 interface RewardsDestination {
-  mainDestinationAddress: string;
-  mainDestinationShare: string;
-  dustDestinationAddress: string;
+  primaryDestinationAddress: string;
+  primaryDestinationShare: string;
+  secondaryDestinationAddress: string;
 }
 
 interface Keystore {
@@ -54,25 +54,68 @@ const start = async (args: { config: string }): Promise<void> => {
   
   const { data: balance } = await api.query.system.account(account.address);
   const decimals = api.registry.chainDecimals;
-  const base = 10**Number(decimals)
-  const dm = Number(balance.free) / base
-  log.debug(`Account ${account.address} has free balance of: ${dm} ${api.registry.chainTokens}`)
+  const base = 10**Number(decimals);
+  const dm = Number(balance.free) / base;
+  log.debug(`Account ${account.address} has free balance of: ${dm} ${api.registry.chainTokens}`);
 
   const existentialDeposit = Number(api.consts.balances.existentialDeposit) / base;
   // Sending funds to addresses
-  const share = parseFloat(config.rewardsDestination.mainDestinationShare) / 100;
-  log.debug(`Share split: ${share * 100}%`)
-  const mainBalance = (Number(balance.free)/ base) *share;
-  const dustBalance = (Number(balance.free)/ base) * (1-share);
-  log.debug(`Will send ${mainBalance} ${api.registry.chainTokens} to ${config.rewardsDestination.mainDestinationAddress}`)
-  log.debug(`Will send ${dustBalance} ${api.registry.chainTokens} (minus fees) to ${config.rewardsDestination.dustDestinationAddress}`)
-  if(mainBalance < existentialDeposit || dustBalance < existentialDeposit) {
-    log.debug(`Warning, sending less than the Existencial Deposit! If target address has less than that it will be lost! Press Ctrl+C now to stop!`)
-    await delay(10000);
+  const share = parseFloat(config.rewardsDestination.primaryDestinationShare) / 100;
+  log.debug(`Share split: ${share * 100}%`);
+
+  // We need to handle the ED of three addresses. First, we need to make sure that the balance of the Account we send from will not fall
+  // below the ED after sending it. Afterwards, we need to make sure that funds do not get lost on the primaryDestinationAddress and 
+  // secondaryDestinationAddress. There are two options here. Either the available_funds * share and available_funds * (1 - share) are both
+  // above the ED or, if they are below the ED, both primaryDestinationAddress and secondaryDestinationAddress are already having more than the ED.
+  // We only want to execute the transactions if no funds are lost anywhere, this should work without user interaction.
+
+  // Get primary and secondary account balances.
+  const { data: balance_primaryDestination } = await api.query.system.account(config.rewardsDestination.primaryDestinationAddress);
+  const { data: balance_secondaryDestination } = await api.query.system.account(config.rewardsDestination.secondaryDestinationAddress);
+
+  var primaryDestinationOverED;
+  var secondaryDestinationOverED;
+
+  // We check whether the two destination addresses have the ED.
+  if((Number(balance_primaryDestination.free) / base) >= existentialDeposit){
+    primaryDestinationOverED = true;
+  } else {
+    primaryDestinationOverED = false;
   }
+
+  if((Number(balance_secondaryDestination.free) / base) >= existentialDeposit){
+    secondaryDestinationOverED = true;
+  } else {
+    secondaryDestinationOverED = false;
+  }
+
+  // We make sure that the remaining funds are exactly the ED.
+  // TODO: We need to reserve funds for two upcoming transactions. How do we do this? Right now, I just heuristically reserve 
+  // 2x a tenth of the ED.
+  const available_funds = (Number(balance.free)/ base) - existentialDeposit - 2*(existentialDeposit/10);
+
+  // Check if we send the available_funds, that the remaining balance (minus ED) is positive. This is the first condition that needs to hold
+  // in all cases.
+  assert(available_funds >= 0)
+
+  const primaryTransfer = available_funds * share;
+  const secondaryTransfer = available_funds * (1-share);
+
+  // Abort if primary destination does not have enough ED and the transfer would be below ED.
+  if(primaryDestinationOverED == false && (primaryTransfer < existentialDeposit)){
+    abort();
+  }
+  // Abort if secondary destination does not have enough ED and the transfer would be below ED.
+  if(secondaryDestinationOverED == false && (secondaryTransfer < existentialDeposit)){
+    abort();
+  }
+
+  log.debug(`Will send ${primaryTransfer} ${api.registry.chainTokens} to ${config.rewardsDestination.primaryDestinationAddress}`)
+  log.debug(`Will send ${secondaryTransfer} ${api.registry.chainTokens} (minus fees) to ${config.rewardsDestination.secondaryDestinationAddress}`)
+  
   const transfers = [
-    api.tx.balances.transfer(config.rewardsDestination.mainDestinationAddress, mainBalance * base),
-    api.tx.balances.transferAll(config.rewardsDestination.dustDestinationAddress, false)
+    api.tx.balances.transfer(config.rewardsDestination.primaryDestinationAddress, primaryTransfer * base),
+    api.tx.balances.transfer(config.rewardsDestination.secondaryDestinationAddress, secondaryTransfer * base)
   ];
   await api.tx.utility
   .batch(transfers)
@@ -89,7 +132,7 @@ function delay(ms: number) {
 }
 
 const command = new Command()
-  .description("Execute the CSV payouts")
+  .description("Execute the reward transactions")
   .option("-c, --config [path]", "Path to config file.", "./config/main.yaml")
   .action(start);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,8 +98,8 @@ const start = async (args: { config: string }): Promise<void> => {
   // in all cases.
   assert(available_funds >= 0)
 
-  const primaryTransfer = Math.round(available_funds * share,10);
-  const secondaryTransfer = Math.round(available_funds * (1-share),10);
+  const primaryTransfer = available_funds * share;
+  const secondaryTransfer = available_funds * (1-share);
 
   // Abort if any of the destination addresses does not have enough ED and the transfer would be below ED. In the case that we do not send
   // anything to the address, we can proceed even if it is without ED.
@@ -115,8 +115,8 @@ const start = async (args: { config: string }): Promise<void> => {
   log.debug(`Will send ${secondaryTransfer} ${api.registry.chainTokens} to ${config.rewardsDestination.secondaryDestinationAddress}`)
   
   const transfers = [
-    api.tx.balances.transfer(config.rewardsDestination.primaryDestinationAddress, primaryTransfer * base),
-    api.tx.balances.transfer(config.rewardsDestination.secondaryDestinationAddress, secondaryTransfer * base)
+    api.tx.balances.transfer(config.rewardsDestination.primaryDestinationAddress, Math.round(primaryTransfer * base)),
+    api.tx.balances.transfer(config.rewardsDestination.secondaryDestinationAddress, Math.round(secondaryTransfer * base))
   ];
   await api.tx.utility
   .batch(transfers)


### PR DESCRIPTION
There are several new conditions that make sure that the funds that are sent would not reduce the balance on the origin account below the ED. It also makes sure that the two destination accounts have more than the ED (then the tx amount does not matter) or would be topped up with more than the ED (if the destination accounts have less than the ED).

Currently, I use a heuristicis to cover tx-fees of ED/10 but we need to hope that the fees stay below that, otherwise we would send more than ED to a destination, which would get reduced to less than ED trough tx-fees, and then would get lost if the destination has no ED.